### PR TITLE
Fix LRU cache value goes missing on get bug.

### DIFF
--- a/components/interfaces.py
+++ b/components/interfaces.py
@@ -18,13 +18,3 @@ class CacheInterface(metaclass=ABCMeta):
     @abstractmethod
     def size(self):
         pass
-
-
-class LinkedListInterface(metaclass=ABCMeta):
-    @abstractmethod
-    def insert_at_front(self, node):
-        pass
-
-    @abstractmethod
-    def delete_node(self, node):
-        pass


### PR DESCRIPTION
- Created a new LRU cache specific doubly linked list.
- Moved linked list methods into this new class.
- LRU cache now extends the new linked list class.
- Fixed deleting the value from cache on get.